### PR TITLE
drop testify dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/ashanbrown/makezero
 
 go 1.12
 
-require (
-	github.com/stretchr/testify v1.4.0
-	golang.org/x/tools v0.1.9
-)
+require golang.org/x/tools v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -33,7 +26,3 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/makezero/makezero_test.go
+++ b/makezero/makezero_test.go
@@ -3,9 +3,8 @@ package makezero
 import (
 	"go/parser"
 	"go/token"
+	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMakeZero(t *testing.T) {
@@ -120,11 +119,14 @@ func foo() {
 
 func expectIssues(t *testing.T, linter *Linter, contents string, issues ...string) {
 	actualIssues := parseFile(t, linter, contents)
-	actualIssueStrs := make([]string, 0, len(actualIssues))
+	var actualIssueStrs []string
 	for _, i := range actualIssues {
 		actualIssueStrs = append(actualIssueStrs, i.String())
 	}
-	assert.ElementsMatch(t, issues, actualIssueStrs)
+
+	if !reflect.DeepEqual(issues, actualIssueStrs) {
+		t.Errorf("\nExpected:%v\nGot:%v\n", issues, actualIssueStrs)
+	}
 }
 
 func parseFile(t *testing.T, linter *Linter, contents string) []Issue {


### PR DESCRIPTION
makezero is only using `assert.ElementsMatch` once which can be easily replaced with `reflect.DeepEqual`