### PR TITLE
Add v2 version support for makezero module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ashanbrown/makezero
+module github.com/ashanbrown/makezero/v2
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/tools/go/packages"
 
-	"github.com/ashanbrown/makezero/makezero"
+	"github.com/ashanbrown/makezero/v2/makezero"
 )
 
 func main() {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"go/ast"
 
-	"github.com/ashanbrown/makezero/makezero"
+	"github.com/ashanbrown/makezero/v2/makezero"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -3,7 +3,7 @@ package analyzer_test
 import (
 	"testing"
 
-	"github.com/ashanbrown/makezero/pkg/analyzer"
+	"github.com/ashanbrown/makezero/v2/pkg/analyzer"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 


### PR DESCRIPTION
Starting with version 2.x need support to pull module,
```
go get -u github.com/ashanbrown/makezero/v2
```

Even pkg docs points v1.2.0 https://pkg.go.dev/github.com/ashanbrown/makezero